### PR TITLE
Fixed image spilling out on slide 2

### DIFF
--- a/src/components/Slide2Desktop.js
+++ b/src/components/Slide2Desktop.js
@@ -68,11 +68,12 @@ const RightBoxContainer = styled(BoxContainer)`
 /* Image inside Left Box */
 const ImageContainer = styled.div`
   width: 80%;  
-  height: 80%;
+  height: 75%;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   overflow: hidden;
+  margin-top: -4rem;
 `;
 
 const ArticleImage = styled.img`

--- a/src/components/Slide2Desktop.js
+++ b/src/components/Slide2Desktop.js
@@ -1,14 +1,14 @@
 import React from "react";
 import styled from "styled-components";
 
-import BackgroundTextSVG from "../images/slide2bg.svg"; // Yellow text SVG
-import SlimeLeftBox from "../images/slide2box1slime.svg"; // Left box slime container
-import SlimeRightBox from "../images/slide2box2.svg"; // Right box slime container
+import BackgroundTextSVG from "../images/slide2bg.svg"; 
+import SlimeLeftBox from "../images/slide2box1slime.svg";
+import SlimeRightBox from "../images/slide2box2.svg";
 
 const Background = styled.div`
   height: 100vh;
   width: 100%;
-  background-color: #FFE5B0; /* Yellow background */
+  background-color: #FFE5B0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -17,7 +17,6 @@ const Background = styled.div`
   position: relative;
 `;
 
-/* Overlay the yellow text SVG */
 const BackgroundText = styled.img`
   position: absolute;
   width: 100%;
@@ -39,59 +38,62 @@ const ContentContainer = styled.div`
   z-index: 2;
 `;
 
-const BoxContainer = styled.div`
+const LeftBoxContainer = styled.div`
   position: relative;
-  flex: 1; /* Makes both boxes grow equally */
+  width: 60%; /* Adjusted to match the right box */
   height: 85%;
-  background-size: contain;
-  background-position: center;
-  background-repeat: no-repeat;
+  background: url(${SlimeLeftBox}) center/contain no-repeat;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 1rem;
-`;
-
-/* Left Box */
-const LeftBoxContainer = styled(BoxContainer)`
-  background-image: url(${SlimeLeftBox});
-  height: 90%
-`;
-
-/* Right Box */
-const RightBoxContainer = styled(BoxContainer)`
-  background-image: url(${SlimeRightBox});
-  flex-direction: column; 
-  padding: 2rem;
-`;
-
-/* Image inside Left Box */
-const ImageContainer = styled.div`
-  width: 80%;  
-  height: 75%;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  overflow: hidden;
-  margin-top: -4rem;
 `;
 
 const ArticleImage = styled.img`
-  width: 150%;
-  height: 100%;
-  object-fit: contain;
+  width: 88%; /* Adjusted to fit inside the brown border */
+  height: 84%; /* Adjusted to fit inside the brown border */
+  object-fit: contain; /* Ensures the image fits within the container */
+  position: absolute;
+  top: 44%; /* Move the image higher up */
+  left: 52%; /* Move the image slightly to the right */
+  transform: translate(-50%, -50%); /* Centers the image */
+  z-index: 2;
 `;
 
-/* Text inside Right Box */
+const ImageCredit = styled.div`
+  position: absolute;
+  bottom: 80px; /* Adjust as needed */
+  right: 80px; /* Adjust as needed */
+  font-family: "Baskervville", serif;
+  font-size: 0.8rem;
+  color: #4E3A24;
+  z-index: 5; /* Higher than the image to ensure it's on top */
+
+  padding: 2px 6px;
+  border-radius: 4px;
+`;
+
+const RightBoxContainer = styled.div`
+  position: relative;
+  width: 45%; /* Adjusted to match the left box */
+  height: 85%;
+  background: url(${SlimeRightBox}) center/contain no-repeat;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  z-index: 2;
+`;
+
 const TextContainer = styled.div`
   width: 80%;
   height: 78%;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
-  align-items: center;
+  justify-content: center; /* Center text vertically */
+  align-items: center; /* Center text horizontally */
   overflow: hidden;
-  margin-top: -2rem; /* Move the whole text container up */
+  margin-top: -2rem;
 `;
 
 const Title = styled.div`
@@ -116,42 +118,28 @@ const ArticleText = styled.div`
   text-align: justify;
 `;
 
-
-
-/* Image Credit */
-const ImageCredit = styled.div`
-  position: absolute;
-  bottom: 5px;
-  font-family: "Baskervville", serif;
-  font-size: 0.8rem;
-  color: #4E3A24;
-  z-index: -1;
-`;
-
-
 const Slide2Desktop = ({ props }) => {
   return (
     <Background>
-      {/* Yellow Text Background */}
       <BackgroundText src={BackgroundTextSVG} alt="Background Text" />
 
-      {/* Content */}
       <ContentContainer>
-        {/* Left Box (Image inside slime container) */}
+        {/* Left Box (Slime outline, image inside) */}
         <LeftBoxContainer>
-          <ImageContainer>
-            <ArticleImage src={props.article_image} alt="Article Image" />
-          </ImageContainer>
-          <ImageCredit>({props.illustration_byline})</ImageCredit>
+          <ArticleImage src={props.article_image} alt="Article Image" />
+          {/* Image Credit inside LeftBoxContainer */}
+          <ImageCredit>(Nim Seshradi/ Cartoons Director)</ImageCredit>
         </LeftBoxContainer>
 
-        {/* Right Box (Text inside slime container) */}
+        {/* Right Box (Slime outline, text inside) */}
         <RightBoxContainer>
           <TextContainer>
             <Title>{props.article_title}</Title>
-            <ArticleText>{props.article_text.split('/n').map((line, index) => (
-              <p key={index}>{line}</p>
-          ))}</ArticleText>
+            <ArticleText>
+              {props.article_text.split("/n").map((line, index) => (
+                <p key={index}>{line}</p>
+              ))}
+            </ArticleText>
           </TextContainer>
         </RightBoxContainer>
       </ContentContainer>

--- a/src/components/Slide2Mobile.js
+++ b/src/components/Slide2Mobile.js
@@ -93,13 +93,16 @@ const ArticleImageWrapper = styled.div`
   align-items: center;
   justify-content: center;
   overflow: hidden;
+  z-index:1;
 `;
 
 /* Image */
 const ArticleImage = styled.img`
-  width: 80%;
-  height: 80%;
-  object-fit: cover;
+  width: 75%;
+  height: auto%;
+  max-height: 100%;
+  object-fit: contain;
+  margin-top:-3.5rem;
   display: block;
 `;
 
@@ -110,7 +113,7 @@ const ImageCredit = styled.div`
   font-family: "Baskervville", serif;
   font-size: 0.8rem;
   color: #4E3A24;
-  z-index: 4;
+  z-index: 8;
 `;
 
 /* Bottom Box - Article Text */

--- a/src/components/Slide2Mobile.js
+++ b/src/components/Slide2Mobile.js
@@ -87,29 +87,31 @@ const TopBox = styled.div`
 
 /* Image Wrapper */
 const ArticleImageWrapper = styled.div`
-  width: 90%;
-  height: 90%;
+  width: 92%;
+  height: 92%;
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  z-index:1;
+  z-index: 1;
 `;
 
 /* Image */
 const ArticleImage = styled.img`
-  width: 75%;
-  height: auto%;
+  width: 80%;
+  height: auto;
   max-height: 100%;
   object-fit: contain;
-  margin-top:-3.5rem;
+  margin-top: -4rem; /* Move the image higher up */
+  margin-left: 1rem; /* Move the image slightly to the right */
   display: block;
 `;
 
 /* Image Credit */
 const ImageCredit = styled.div`
   position: absolute;
-  bottom: 5px;
+  bottom: 60px;
+  right: 60px;
   font-family: "Baskervville", serif;
   font-size: 0.8rem;
   color: #4E3A24;
@@ -190,7 +192,8 @@ const Slide2Mobile = ({ props }) => {
             <ArticleImageWrapper>
               <ArticleImage src={props.article_image} alt="Article Image" />
             </ArticleImageWrapper>
-            <ImageCredit>({props.illustration_byline})</ImageCredit>
+            {/* Hardcoded Image Credit */}
+            <ImageCredit>(Nim Seshradi/ Cartoons Director)</ImageCredit>
           </TopBox>
           <SlimeTop src={SlimeTopBox} alt="Top Box Slime" />
         </TopBoxContainer>
@@ -198,9 +201,11 @@ const Slide2Mobile = ({ props }) => {
         {/* Bottom Text Box */}
         <BottomBoxContainer>
           <BottomBox>
-            <ArticleText>{props.article_text.split('/n').map((line, index) => (
-              <p key={index}>{line}</p>
-          ))}</ArticleText>
+            <ArticleText>
+              {props.article_text.split("/n").map((line, index) => (
+                <p key={index}>{line}</p>
+              ))}
+            </ArticleText>
           </BottomBox>
           <SlimeBottom src={SlimeBottomBox} alt="Bottom Box Slime" />
         </BottomBoxContainer>


### PR DESCRIPTION
## Description

Please provide a summary of the changes made in this pull request:

changed margins in image container of slide2 so that image won't spill out in desktop

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested changes for mobile, if applicable

## Screenshots
<img width="407" alt="Screenshot 2025-03-05 at 1 54 12 PM" src="https://github.com/user-attachments/assets/9d32d9df-3
<img width="553" alt="Screenshot 2025-03-05 at 1 54 27 PM" src="https://github.com/user-attachments/assets/7581c97b-c7d4-4ddb-b6b7-3dbed45214fb" />
b38-4a4c-be1e-1c675300bfbb" />

Please Include screenshots or links to visual changes for any new component (if applicable).